### PR TITLE
Reword title

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en-US" class="bae-warm bae-clean rhythm-5" id="top">
-<title>City Dance *moves*</title>
+<title>City Dance moves San Francisco</title>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <meta name="description" content="Got movement? This San Francisco dance school moves.">


### PR DESCRIPTION
Preview in Google was showing only 1 `*`

> City Dance *moves - s9a
> https://s9a.github.io/city_dance_moves/
> Got movement? This San Francisco dance school moves.

So I removed the markdown stars